### PR TITLE
Recreate the tmp directory when unik daemon deploy a new listener on vSphere

### DIFF
--- a/instance-listener/main.go
+++ b/instance-listener/main.go
@@ -90,7 +90,7 @@ func main() {
 				log.Printf("ERROR: broadcast-ip: %v; failed writing to broadcast udp socket: "+err.Error(), BROADCAST_IPv4)
 				return
 			}
-			time.Sleep(1000 * time.Millisecond)
+			time.Sleep(5000 * time.Millisecond)
 		}
 	}()
 	m := http.NewServeMux()

--- a/pkg/providers/vsphere/vsphere_provider.go
+++ b/pkg/providers/vsphere/vsphere_provider.go
@@ -51,7 +51,7 @@ func NewVsphereProvier(config config.Vsphere) (*VsphereProvider, error) {
 	p.getClient().Mkdir("unik/vsphere/volumes")
 
 	if err := p.deployInstanceListener(); err != nil {
-		return nil, errors.New("deploying virtualbox instance listener", err)
+		return nil, errors.New("deploying vsphere instance listener", err)
 	}
 
 	instanceListenerIp, err := common.GetInstanceListenerIp(instanceListenerPrefix, timeout)

--- a/pkg/providers/vsphere/vsphere_provider.go
+++ b/pkg/providers/vsphere/vsphere_provider.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
+	"os"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/emc-advanced-dev/pkg/errors"
@@ -59,6 +60,12 @@ func NewVsphereProvier(config config.Vsphere) (*VsphereProvider, error) {
 	}
 
 	p.instanceListenerIp = instanceListenerIp
+
+	tmpDir := filepath.Join(os.Getenv("HOME"), ".unik", "tmp")
+        os.Setenv("TMPDIR", tmpDir)
+        logrus.Infof("Creating directory %s", tmpDir)
+        os.MkdirAll(tmpDir, 0755)
+
 	// begin update instances cycle
 	go func() {
 		for {


### PR DESCRIPTION
Fix the issue https://github.com/cf-unik/unik/issues/140