### PR TITLE
Update baseimage to golang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
-FROM ubuntu:16.04
+FROM golang:1.7.6
 
 RUN apt-get update && apt-get install -y curl make git jq
-
-RUN curl --insecure https://storage.googleapis.com/golang/go1.7.6.linux-amd64.tar.gz | tar xz -C /usr/local
 
 ENV GOROOT=/usr/local/go
 ENV GOPATH=/go


### PR DESCRIPTION
Docker build with insecure get  of go version 1.7.6 was failing, switch to official image of https://hub.docker.com/_/golang fixed it for me.