### PR TITLE
Use Go's cross-platform process killing instead of the UNIX-only syscall.Kill

### DIFF
--- a/pkg/providers/qemu/stop_instance_cgo.go
+++ b/pkg/providers/qemu/stop_instance_cgo.go
@@ -3,12 +3,13 @@
 package qemu
 
 import (
+	"os"
+	"strconv"
 	"syscall"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/emc-advanced-dev/pkg/errors"
 	"github.com/solo-io/unik/pkg/types"
-	"strconv"
 )
 
 func (p *QemuProvider) StopInstance(id string) error {
@@ -23,9 +24,15 @@ func (p *QemuProvider) StopInstance(id string) error {
 		return errors.New("invalid instance id (should be qemu pid)", err)
 	}
 
-	if err := syscall.Kill(pid, syscall.SIGKILL); err != nil {
-		logrus.Warn("failed terminating instance, assuming instance has externally terminated", err)
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		logrus.Warn("failed finding instance, assuming instance has externally terminated", err)
+	} else {
+		if err := process.Signal(syscall.SIGKILL); err != nil {
+			logrus.Warn("failed terminating instance, assuming instance has externally terminated", err)
+		}
 	}
+
 	volumesToDetach := []*types.Volume{}
 	volumes, err := p.ListVolumes()
 	if err != nil {


### PR DESCRIPTION
The system call ``syscall.Kill(pid, syscall.SIGKILL)`` is not available on Windows. So I replace it with a more cross-platform way which supports all OSes. Now Unik can be compiled on Windows.

```
GOROOT=C:\Go #gosetup
GOPATH=C:\GoPath #gosetup
C:\Go\bin\go.exe build -i -o C:\Users\xxx\AppData\Local\Temp\___go_build_unik_go.exe C:/GoPath/src/github.com/solo-io/unik/unik.go #gosetup
"C:\Program Files\JetBrains\GoLand 2018.1.5\bin\runnerw.exe" C:\Users\xxx\AppData\Local\Temp\___go_build_unik_go.exe #gosetup
Unik is a tool for compiling application source code
into bootable disk images. Unik also runs and manages unikernel
instances across infrastructures.

Create a client configuration file with 'unik target'

You may set a custom client configuration file
with the global flag --client-config=<path>

Usage:
  unik [command]

Available Commands:
  attach-volume     Attach a volume to a stopped instance
  build             Build a unikernel image from source code files
  compilers         List available unikernel compilers
  configure         A generate configuration file for daemon ('daemon.yaml')
  create-volume     Create a unik-managed data volume
  daemon            Runs the unik backend (daemon)
  delete-image      Delete a unikernel image
  delete-instance   Delete a unikernel instance
  delete-volume     Delete a unikernel volume
  describe-compiler Describe compiler usage
  describe-image    Get image info as a Json string
  describe-instance Get instance info as a Json string
  detach-volume     Detach an attached volume from a stopped instance
  images            List available unikernel images
  instances         List pending/running/stopped unik instances
  login             Log in to a Unik Repository to pull & push images
  logs              retrieve the logs (stdout) of a unikernel instance
  providers         List available unikernel providers
  pull              Pull an image from a Unik Image Repository
  push              Push an image to a Unik Image Repository
  remote-delete     Deleted a pushed image from a Unik Hub Repository
  run               Run a unikernel instance from a compiled image
  search            Search available images in the targeted Unik Image Repository
  start             Start a stopped unikernel instance
  stop              Stop a running unikernel instance
  target            Configure unik daemon URL for cli client commands
  volumes           List available unik-managed volumes

Flags:
      --client-config="/.unik/client-config.yaml": client config file
  -h, --help[=false]: help for unik
      --host="": <string, optional>: host/ip address of the host running the unik daemon
      --hub-config="/.unik/hub-config.yaml": hub config file

Use "unik [command] --help" for more information about a command.

Process finished with exit code 0
```



