### PR TITLE
Support config files located in home directory on Windows.

### DIFF
--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -96,7 +96,7 @@ Example usage:
 
 func init() {
 	RootCmd.AddCommand(daemonCmd)
-	daemonCmd.Flags().StringVar(&daemonRuntimeFolder, "d", os.Getenv("HOME")+"/.unik/", "daemon runtime folder - where state is stored. (default is $HOME/.unik/)")
+	daemonCmd.Flags().StringVar(&daemonRuntimeFolder, "d", getHomeDir()+"/.unik/", "daemon runtime folder - where state is stored. (default is $HOME/.unik/)")
 	daemonCmd.Flags().StringVar(&daemonConfigFile, "f", "", "daemon config file (default is {RuntimeFolder}/daemon-config.yaml)")
 	daemonCmd.Flags().IntVar(&port, "port", 3000, "<int, optional> listening port for daemon")
 	daemonCmd.Flags().BoolVar(&debugMode, "debug", false, "<bool, optional> more verbose logging for the daemon")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"runtime"
+	"sort"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -12,7 +14,6 @@ import (
 
 	"github.com/solo-io/unik/pkg/config"
 	"github.com/solo-io/unik/pkg/types"
-	"sort"
 )
 
 var clientConfigFile, hubConfigFile, host string
@@ -31,9 +32,17 @@ You may set a custom client configuration file
 with the global flag --client-config=<path>`,
 }
 
+func getHomeDir() string {
+	if runtime.GOOS == "windows" {
+		return os.Getenv("USERPROFILE")
+	} else {
+		return os.Getenv("HOME")
+	}
+}
+
 func init() {
-	RootCmd.PersistentFlags().StringVar(&clientConfigFile, "client-config", os.Getenv("HOME")+"/.unik/client-config.yaml", "client config file")
-	RootCmd.PersistentFlags().StringVar(&hubConfigFile, "hub-config", os.Getenv("HOME")+"/.unik/hub-config.yaml", "hub config file")
+	RootCmd.PersistentFlags().StringVar(&clientConfigFile, "client-config", getHomeDir()+"/.unik/client-config.yaml", "client config file")
+	RootCmd.PersistentFlags().StringVar(&hubConfigFile, "hub-config", getHomeDir()+"/.unik/hub-config.yaml", "hub config file")
 	RootCmd.PersistentFlags().StringVar(&host, "host", "", "<string, optional>: host/ip address of the host running the unik daemon")
 	targetCmd.Flags().IntVar(&port, "port", 3000, "<int, optional>: port the daemon is running on (default: 3000)")
 }


### PR DESCRIPTION
The current code fails to get the home directory on Windows. This PR will get home like ``C:\Users\xxx`` on Windows.

This fixed: https://github.com/solo-io/unik/issues/158