### PR TITLE
Remove cgo build tag from stop_instance.go firecracker provider

### DIFF
--- a/pkg/providers/firecracker/stop_instance.go
+++ b/pkg/providers/firecracker/stop_instance.go
@@ -1,5 +1,3 @@
-// +build cgo
-
 package firecracker
 
 import (


### PR DESCRIPTION
Seems like it was copy/pasted by mistake but causing builds to fail because builds don't enable CGO by default.
Removing it because it doesn't seem like it is needed in that file

Causing issue: https://github.com/solo-io/unik/issues/179
