### PR TITLE
README.md: correct "AWS Firecracker" references

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Due to the frequency with which features and patches are applied to UniK, we hav
   - [Launching the InstanceListener](docs/instance_listener.md)
 - **Getting Started**
   - [Pull and run a unikernel without building](docs/getting_started_pull.md) on Virtualbox with UniK
-  - [Run your first Go MicroVM](docs/compilers/firecracker.md) on AWS Firecracker with Unik
+  - [Run your first Go MicroVM](docs/compilers/firecracker.md) on Firecracker with Unik
   - [Run your first Go unikernel](docs/getting_started.md) on Virtualbox with UniK
   - [Run your first Node.js unikernel](docs/getting_started_node.md) on Virtualbox with UniK
   - [Run your first Python3 unikernel](docs/getting_started_python3.md) on Virtualbox with UniK
@@ -56,7 +56,7 @@ Due to the frequency with which features and patches are applied to UniK, we hav
 ---
 
 ### Supported unikernel types:
-* **AWS Firecracker**: UniK supports compiling GO code into [AWS Firecracker](https://aws.amazon.com/blogs/aws/firecracker-lightweight-virtualization-for-serverless-computing/) MicroVMs
+* **Firecracker**: UniK supports compiling GO code into [Firecracker](https://firecracker-microvm.github.io/) MicroVMs
 * **rump**: UniK supports compiling [Python](docs/compilers/rump.md#python-3), [Node.js](docs/compilers/rump.md#nodejs) and [Go](docs/compilers/rump.md#golang) code into [rumprun](docs/compilers/rump.md) unikernels
 * **OSv**: UniK supports compiling Java, Node.js, C and C++ code into [OSv](http://osv.io/) unikernels
 * **IncludeOS**: UniK supports compiling C++ code into [IncludeOS](https://github.com/hioa-cs/IncludeOS) unikernels
@@ -65,7 +65,7 @@ Due to the frequency with which features and patches are applied to UniK, we hav
 *We are looking for community help to add support for more unikernel types and languages.*
 
 ### Supported providers:
-* [AWS Firecracker](https://aws.amazon.com/blogs/aws/firecracker-lightweight-virtualization-for-serverless-computing/)
+* [Firecracker](https://firecracker-microvm.github.io/)
 * [Virtualbox](docs/providers/virtualbox.md)
 * [AWS](docs/providers/aws.md)
 * [Google Cloud](docs/providers/gcloud.md)


### PR DESCRIPTION
... to be just "Firecracker" (AWS is not part of the name). Also point to the upstream open source project homepage, rather than an AWS blog.