### PR TITLE
Bumps golang docker image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.1
+FROM golang:1.11.13
 
 RUN apt-get update && apt-get install -y curl make git jq
 


### PR DESCRIPTION
Bumps golang docker image version from 1.11.1 to 1.11.13 to fix apt-get update errors.